### PR TITLE
refactor/use diff packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ coverage/
 demo/
 demo.*
 changelog-*.md
+
+docs/coverage*

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ deps: ## Download and update dependencies
 test: ## Run tests
 	go test -v ./...
 
+.PHONY: coverage
+coverage: ## Run tests with coverage and show percentage
+	mkdir -p docs
+	go test -coverprofile=docs/coverage.out ./... && go tool cover -func=docs/coverage.out | grep total:
+	@echo "HTML report: open docs/coverage.html"
+	go tool cover -html=docs/coverage.out -o docs/coverage.html
+
 ##@ Aliases
 
 .PHONY: r
@@ -86,3 +93,7 @@ t: ## test App (command alias)
 .PHONY: c
 c: ## clean App (command alias)
 	@make clean
+
+.PHONY: cov
+cov: ## Test coverage (command alias)
+	@make coverage

--- a/README.md
+++ b/README.md
@@ -116,8 +116,30 @@ go build -tags dev
 - End-to-end API test recorder
 - Cloud sync and team collaboration
 
-## License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+## Test Coverage
+
+To check test coverage and generate a report, run:
+
+```bash
+make coverage
+```
+
+Example output:
+```
+$ make coverage
+mkdir -p docs
+go test -coverprofile=docs/coverage.out ./... && go tool cover -func=docs/coverage.out | grep total:
+	github.com/romanitalian/GHOSTman		coverage: 0.0% of statements
+ok  	github.com/romanitalian/GHOSTman/internal/collection	0.005s	coverage: 81.8% of statements
+ok  	github.com/romanitalian/GHOSTman/internal/httpclient	0.008s	coverage: 85.2% of statements
+	github.com/romanitalian/GHOSTman/internal/logging		coverage: 0.0% of statements
+	github.com/romanitalian/GHOSTman/internal/ui		coverage: 0.0% of statements
+total:									(statements)		19.3%
+HTML report: open docs/coverage.html
+go tool cover -html=docs/coverage.out -o docs/coverage.html
+```
+
+You can open `docs/coverage.html` in your browser for a detailed report.
 
 ## Contributing
 1. Fork the repository
@@ -125,3 +147,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 3. Commit your changes (`git commit -m 'feat: entity - add amazing feature'`)
 4. Push to the branch (`git push --force-with-lease origin feature/amazing-feature`)
 5. Open a Pull Request
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/internal/collection/collection.go
+++ b/internal/collection/collection.go
@@ -1,0 +1,69 @@
+package collection
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Cllns represents the structure of the collection JSON (Postman collection format)
+type Cllns struct {
+	Info struct {
+		Name string `json:"name"`
+	} `json:"info"`
+	Item []struct {
+		Name    string `json:"name"`
+		Request struct {
+			Method      string `json:"method"`
+			Description string `json:"description"`
+			Header      []struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+			} `json:"header"`
+			Body struct {
+				Mode string `json:"mode"`
+				Raw  string `json:"raw"`
+			} `json:"body"`
+			URL struct {
+				Raw  string   `json:"raw"`
+				Host []string `json:"host"`
+				Path []string `json:"path"`
+			} `json:"url"`
+		} `json:"request"`
+	} `json:"item"`
+	Variable []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+		Type  string `json:"type"`
+	} `json:"variable"`
+}
+
+// substituteVariables replaces {{var}} in a string with values from vars
+func SubstituteVariables(s string, vars map[string]string) string {
+	for k, v := range vars {
+		placeholder := "{{" + k + "}}"
+		s = strings.ReplaceAll(s, placeholder, v)
+	}
+	return s
+}
+
+// LoadPostmanCollection loads and parses the Postman collection from file
+type FormMeta struct {
+	ID    string
+	Title string
+	Intro string
+}
+
+func LoadPostmanCollection(path string) (*Cllns, error) {
+	data, err := os.ReadFile(filepath.Join(path))
+	if err != nil {
+		return nil, fmt.Errorf("error reading Postman collection: %v", err)
+	}
+	var collection Cllns
+	if err := json.Unmarshal(data, &collection); err != nil {
+		return nil, fmt.Errorf("error parsing Postman collection: %v", err)
+	}
+	return &collection, nil
+}

--- a/internal/collection/collection_test.go
+++ b/internal/collection/collection_test.go
@@ -1,0 +1,41 @@
+package collection
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSubstituteVariables(t *testing.T) {
+	vars := map[string]string{"foo": "bar", "name": "Alice"}
+	input := "Hello, {{name}}! Foo is {{foo}}."
+	want := "Hello, Alice! Foo is bar."
+	got := SubstituteVariables(input, vars)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLoadPostmanCollection(t *testing.T) {
+	// Создаём временный файл с минимальной коллекцией
+	jsonData := `{"info":{"name":"Test"},"item":[],"variable":[{"key":"foo","value":"bar","type":"string"}]}`
+	f, err := os.CreateTemp("", "col_test_*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(jsonData); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	f.Close()
+
+	coll, err := LoadPostmanCollection(f.Name())
+	if err != nil {
+		t.Fatalf("LoadPostmanCollection error: %v", err)
+	}
+	if coll.Info.Name != "Test" {
+		t.Errorf("unexpected Info.Name: %q", coll.Info.Name)
+	}
+	if len(coll.Variable) != 1 || coll.Variable[0].Key != "foo" || coll.Variable[0].Value != "bar" {
+		t.Errorf("unexpected variable: %+v", coll.Variable)
+	}
+}

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -1,0 +1,66 @@
+package httpclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var (
+	// Shared HTTP client with timeout
+	Client = &http.Client{
+		Timeout: 10 * time.Second,
+	}
+)
+
+// SendRequest sends an HTTP request and returns status, body, and error
+func SendRequest(rq *http.Request) (statusLine string, prettyBody string, isError bool, err error) {
+	resp, err := Client.Do(rq)
+	if err != nil {
+		return "", "", true, fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	const maxResponseSize = 2 * 1024 * 1024 // 2 MB
+	limitedReader := io.LimitReader(resp.Body, maxResponseSize)
+	bodyRS, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return "", "", true, fmt.Errorf("error reading response: %v", err)
+	}
+
+	statusLine = fmt.Sprintf("HTTP %d %s\n", resp.StatusCode, resp.Status)
+
+	if resp.StatusCode >= 400 {
+		return statusLine, string(bodyRS), true, nil
+	}
+
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, bodyRS, "", "    "); err != nil {
+		return statusLine, string(bodyRS), false, nil
+	}
+
+	return statusLine, prettyJSON.String(), false, nil
+}
+
+// NewRequest creates a new http.Request from method, url, body, and headers string
+func NewRequest(method, url, body, headers string) (*http.Request, error) {
+	rq, err := http.NewRequest(method, url, bytes.NewBufferString(body))
+	if err != nil {
+		return nil, err
+	}
+	hdrs := strings.Split(headers, "\n")
+	for _, h := range hdrs {
+		if h == "" {
+			continue
+		}
+		parts := strings.SplitN(h, ":", 2)
+		if len(parts) == 2 {
+			rq.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+	return rq, nil
+}

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -1,0 +1,50 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewRequest(t *testing.T) {
+	rq, err := NewRequest("POST", "http://example.com", "body", "X-Test: 123\nContent-Type: text/plain")
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if rq.Method != "POST" || rq.URL.String() != "http://example.com" {
+		t.Errorf("unexpected method or url: %s %s", rq.Method, rq.URL)
+	}
+	if rq.Header.Get("X-Test") != "123" || rq.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf("unexpected headers: %v", rq.Header)
+	}
+}
+
+func TestSendRequest(t *testing.T) {
+	// Мок-сервер
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/err" {
+			w.WriteHeader(500)
+			w.Write([]byte("fail"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	rq, _ := NewRequest("GET", ts.URL, "", "")
+	status, body, isErr, err := SendRequest(rq)
+	if err != nil || isErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(status, "200") || !strings.Contains(body, "ok") {
+		t.Errorf("unexpected status/body: %s %s", status, body)
+	}
+
+	rq2, _ := NewRequest("GET", ts.URL+"/err", "", "")
+	status2, body2, isErr2, err2 := SendRequest(rq2)
+	if err2 != nil || !isErr2 || !strings.Contains(status2, "500") || !strings.Contains(body2, "fail") {
+		t.Errorf("unexpected error or response: %v %v %s %s", isErr2, err2, status2, body2)
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,33 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	logLevel      = zerolog.WarnLevel
+	logFormatJSON = true
+)
+
+func InitLogger() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
+	zerolog.SetGlobalLevel(logLevel)
+
+	if logFormatJSON {
+		log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	} else {
+		log.Logger = log.Output(zerolog.ConsoleWriter{
+			Out:        os.Stdout,
+			TimeFormat: "2006-01-02 15:04:05.000",
+			NoColor:    false,
+		})
+	}
+}
+
+var (
+	Log     = log.Logger
+	Zerolog = zerolog.Logger{}
+)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,115 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/romanitalian/GHOSTman/internal/collection"
+	"github.com/romanitalian/GHOSTman/internal/httpclient"
+)
+
+type Form struct {
+	ID    string
+	Title string
+	Intro string
+	Form  fyne.CanvasObject
+}
+
+func CreateForm(item struct {
+	Name    string `json:"name"`
+	Request struct {
+		Method      string `json:"method"`
+		Description string `json:"description"`
+		Header      []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"header"`
+		Body struct {
+			Mode string `json:"mode"`
+			Raw  string `json:"raw"`
+		} `json:"body"`
+		URL struct {
+			Raw  string   `json:"raw"`
+			Host []string `json:"host"`
+			Path []string `json:"path"`
+		} `json:"url"`
+	} `json:"request"`
+}, vars map[string]string) fyne.CanvasObject {
+	frm := &widget.Form{}
+
+	urlEntry := widget.NewEntry()
+	urlEntry.SetText(collection.SubstituteVariables(item.Request.URL.Raw, vars))
+	frm.Append("URL", urlEntry)
+
+	methodSelect := widget.NewSelect([]string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"}, func(value string) {})
+	methodSelect.SetSelected(item.Request.Method)
+	frm.Append("Method", methodSelect)
+
+	var headersText strings.Builder
+	for _, h := range item.Request.Header {
+		headersText.WriteString(fmt.Sprintf("%s: %s\n", h.Key, collection.SubstituteVariables(h.Value, vars)))
+	}
+	hdrsEntry := widget.NewMultiLineEntry()
+	hdrsEntry.SetText(headersText.String())
+	frm.Append("Headers", hdrsEntry)
+
+	bodyEntry := widget.NewMultiLineEntry()
+	bodyEntry.SetText(collection.SubstituteVariables(item.Request.Body.Raw, vars))
+	lines := strings.Count(item.Request.Body.Raw, "\n") + 1
+	bodyEntry.SetMinRowsVisible(lines)
+	frm.Append("Body", bodyEntry)
+
+	textRS := widget.NewMultiLineEntry()
+	textRS.Wrapping = fyne.TextWrapWord
+	textRS.TextStyle = fyne.TextStyle{
+		Bold:      true,
+		Monospace: true,
+	}
+	textRS.Resize(fyne.NewSize(200, 200))
+	textRS.SetMinRowsVisible(25)
+
+	progressBar := widget.NewProgressBarInfinite()
+	progressBar.Hide()
+
+	submitBtn := widget.NewButton("Send", func() {
+		textRS.SetText("")
+		progressBar.Show()
+		progressBar.Refresh()
+
+		rq, err := httpclient.NewRequest(methodSelect.Selected, urlEntry.Text, bodyEntry.Text, hdrsEntry.Text)
+		if err != nil {
+			progressBar.Hide()
+			progressBar.Refresh()
+			textRS.SetText(fmt.Sprintf("Error creating request: %v", err))
+			return
+		}
+
+		go func() {
+			statusLine, prettyBody, _, err := httpclient.SendRequest(rq)
+			fyne.Do(func() {
+				progressBar.Hide()
+				progressBar.Refresh()
+				if err != nil {
+					textRS.SetText(fmt.Sprintf("%s", err))
+					return
+				}
+				textRS.SetText(statusLine + prettyBody)
+			})
+		}()
+	})
+
+	frm.Append("", submitBtn)
+	frm.Append("", progressBar)
+
+	containerRS := container.NewVBox(
+		progressBar,
+		textRS,
+	)
+	frm.Append("Response", containerRS)
+
+	return container.NewVBox(frm)
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -15,337 +8,79 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/widget"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"github.com/romanitalian/GHOSTman/internal/collection"
+	"github.com/romanitalian/GHOSTman/internal/logging"
+	"github.com/romanitalian/GHOSTman/internal/ui"
 )
 
 const (
 	preferenceCurrentForm = "currentForm"
 	minURLPathLength      = 2
 	defaultSplitOffset    = 0.2
-	responseHeightRatio   = 0.3
 	defaultWindowWidth    = 1024
 	defaultWindowHeight   = 768
-
-	logLevel      = zerolog.WarnLevel
-	logFormatJSON = true
 
 	appID    = "com.github.romanitalian.ghostman"
 	appTitle = "GHOSTman"
 )
 
-var (
-	topWindow   fyne.Window
-	httpMethods = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"}
-)
-
-// Cllns represents the structure of the collection JSON (Postman collection format)
-type Cllns struct {
-	Info struct {
-		Name string `json:"name"`
-	} `json:"info"`
-	Item []struct {
-		Name    string `json:"name"`
-		Request struct {
-			Method      string `json:"method"`
-			Description string `json:"description"`
-			Header      []struct {
-				Key   string `json:"key"`
-				Value string `json:"value"`
-			} `json:"header"`
-			Body struct {
-				Mode string `json:"mode"`
-				Raw  string `json:"raw"`
-			} `json:"body"`
-			URL struct {
-				Raw  string   `json:"raw"`
-				Host []string `json:"host"`
-				Path []string `json:"path"`
-			} `json:"url"`
-		} `json:"request"`
-	} `json:"item"`
-	Variable []struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
-		Type  string `json:"type"`
-	} `json:"variable"`
-}
-
-func substituteVariables(s string, vars map[string]string) string {
-	for k, v := range vars {
-		placeholder := "{{" + k + "}}"
-		s = strings.ReplaceAll(s, placeholder, v)
-	}
-	return s
-}
-
-func createForm(item struct {
-	Name    string `json:"name"`
-	Request struct {
-		Method      string `json:"method"`
-		Description string `json:"description"`
-		Header      []struct {
-			Key   string `json:"key"`
-			Value string `json:"value"`
-		} `json:"header"`
-		Body struct {
-			Mode string `json:"mode"`
-			Raw  string `json:"raw"`
-		} `json:"body"`
-		URL struct {
-			Raw  string   `json:"raw"`
-			Host []string `json:"host"`
-			Path []string `json:"path"`
-		} `json:"url"`
-	} `json:"request"`
-}, vars map[string]string) fyne.CanvasObject {
-	// Create form fields
-	frm := &widget.Form{}
-
-	// Add request info fields
-	urlEntry := widget.NewEntry()
-	urlEntry.SetText(substituteVariables(item.Request.URL.Raw, vars))
-	frm.Append("URL", urlEntry)
-
-	methodSelect := widget.NewSelect(httpMethods, func(value string) {})
-	methodSelect.SetSelected(item.Request.Method)
-	frm.Append("Method", methodSelect)
-
-	var headersText strings.Builder
-	for _, h := range item.Request.Header {
-		headersText.WriteString(fmt.Sprintf("%s: %s\n", h.Key, substituteVariables(h.Value, vars)))
-	}
-	hdrsEntry := widget.NewMultiLineEntry()
-	hdrsEntry.SetText(headersText.String())
-	frm.Append("Headers", hdrsEntry)
-
-	// Create body field with fixed height
-	bodyEntry := widget.NewMultiLineEntry()
-	bodyEntry.SetText(substituteVariables(item.Request.Body.Raw, vars))
-
-	// Calculate number of lines in JSON
-	lines := strings.Count(item.Request.Body.Raw, "\n") + 1
-	bodyEntry.SetMinRowsVisible(lines)
-
-	frm.Append("Body", bodyEntry)
-
-	// Create response field
-	textRS := widget.NewMultiLineEntry()
-	textRS.Wrapping = fyne.TextWrapWord
-	textRS.TextStyle = fyne.TextStyle{
-		Bold:      true,
-		Monospace: true,
-	}
-	textRS.Resize(fyne.NewSize(200, 200))
-	textRS.SetMinRowsVisible(25)
-
-	// Create progress bar
-	progressBar := widget.NewProgressBarInfinite()
-	progressBar.Hide() // Hide initially
-
-	// Add submit button
-	submitBtn := widget.NewButton("Send", func() {
-		// Clear response field and show progress
-		textRS.SetText("")
-		progressBar.Show()
-		progressBar.Refresh()
-
-		// Create request
-		rq, err := http.NewRequest(methodSelect.Selected, urlEntry.Text, bytes.NewBufferString(bodyEntry.Text))
-		if err != nil {
-			progressBar.Hide()
-			progressBar.Refresh()
-			textRS.SetText(fmt.Sprintf("Error creating request: %v", err))
-			return
-		}
-
-		// Add headers
-		hdrs := strings.Split(hdrsEntry.Text, "\n")
-		for _, h := range hdrs {
-			if h == "" {
-				continue
-			}
-			parts := strings.SplitN(h, ":", 2)
-			if len(parts) == 2 {
-				rq.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
-			}
-		}
-
-		// Send request in goroutine
-		go func() {
-			client := &http.Client{}
-			resp, err := client.Do(rq)
-			if err != nil {
-				fyne.Do(func() {
-					progressBar.Hide()
-					progressBar.Refresh()
-					textRS.SetText(fmt.Sprintf("Error sending request: %v", err))
-				})
-				return
-			}
-			defer resp.Body.Close()
-
-			// Read response
-			bodyRS, err := io.ReadAll(resp.Body)
-			if err != nil {
-				fyne.Do(func() {
-					progressBar.Hide()
-					progressBar.Refresh()
-					textRS.SetText(fmt.Sprintf("Error reading response: %v", err))
-				})
-				return
-			}
-
-			// Format response
-			var prettyJSON bytes.Buffer
-			if err := json.Indent(&prettyJSON, bodyRS, "", "    "); err != nil {
-				fyne.Do(func() {
-					textRS.SetText(string(bodyRS))
-					progressBar.Hide()
-					progressBar.Refresh()
-				})
-				return
-			}
-
-			// Update response and hide progress
-			fyne.Do(func() {
-				textRS.SetText(prettyJSON.String())
-				progressBar.Hide()
-				progressBar.Refresh()
-			})
-		}()
-	})
-
-	frm.Append("", submitBtn)
-
-	frm.Append("", progressBar)
-
-	// Create response container
-	containerRS := container.NewVBox(
-		progressBar,
-		textRS,
-	)
-
-	// Add response field after submit button
-	frm.Append("Response", containerRS)
-
-	// Create vertical container with form
-	return container.NewVBox(
-		frm,
-	)
-}
-
-type Form struct {
-	ID    string
-	Title string
-	Intro string
-	Form  fyne.CanvasObject
-}
-
-func loadPostmanCollection() ([]Form, error) {
-	var forms []Form
-
-	data, err := os.ReadFile(filepath.Join("data", "col.postman_collection.json"))
-	if err != nil {
-		log.Error().Err(err).Msg("error reading Postman collection")
-		return nil, fmt.Errorf("error reading Postman collection: %v", err)
-	}
-
-	var collection Cllns
-	if err := json.Unmarshal(data, &collection); err != nil {
-		log.Error().Err(err).Msg("error parsing Postman collection")
-		return nil, fmt.Errorf("error parsing Postman collection: %v", err)
-	}
-
-	// Store variables in map
-	vars := make(map[string]string)
-	for _, v := range collection.Variable {
-		vars[v.Key] = v.Value
-	}
-	log.Info().Fields(vars).Msg("Loaded Postman variables")
-
-	log.Info().Int("count", len(collection.Item)).Msg("Total items in collection")
-
-	for i, item := range collection.Item {
-		log.Info().Int("idx", i+1).Str("name", item.Name).Msg("Processing item")
-		log.Info().Interface("url_path", item.Request.URL.Path).Msg("URL Path")
-		if len(item.Request.URL.Path) >= minURLPathLength {
-			formID := item.Request.URL.Path[1]
-			log.Info().Str("form_id", formID).Msg("Form ID")
-
-			// Create form with request info and variable substitution
-			form := createForm(item, vars)
-
-			forms = append(forms, Form{
-				ID:    formID,
-				Title: item.Name,
-				Intro: item.Request.Description,
-				Form:  form,
-			})
-			log.Info().Str("form_id", formID).Str("name", item.Name).Msg("Added form")
-		} else {
-			log.Warn().Str("name", item.Name).Msg("Skipping item: invalid URL path length")
-		}
-	}
-
-	log.Info().Int("count", len(forms)).Msg("Total forms loaded")
-	for _, form := range forms {
-		log.Info().Str("form_id", form.ID).Str("title", form.Title).Msg("Loaded form")
-	}
-
-	return forms, nil
-}
-
 func main() {
-	// Set up zerolog
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
-	zerolog.SetGlobalLevel(logLevel)
-
-	// Configure log output format
-	if logFormatJSON {
-		log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
-	} else {
-		log.Logger = log.Output(zerolog.ConsoleWriter{
-			Out:        os.Stdout,
-			TimeFormat: "2006-01-02 15:04:05.000",
-			NoColor:    false,
-		})
-	}
-
-	log.Info().Msg("Starting application...")
+	logging.InitLogger()
+	logging.Log.Info().Msg("Starting application...")
 
 	a := app.NewWithID(appID)
 	w := a.NewWindow(appTitle)
-	topWindow = w
 
 	content := container.NewStack()
 	title := widget.NewLabel("Form Title")
 	intro := widget.NewLabel("Form description goes here")
 	intro.Wrapping = fyne.TextWrapWord
-
 	top := container.NewVBox(title, widget.NewSeparator(), intro)
 
 	setForm := func(form fyne.CanvasObject, formTitle string, formIntro string) {
-		log.Info().Str("form_title", formTitle).Msg("Setting form")
+		logging.Log.Info().Str("form_title", formTitle).Msg("Setting form")
 		title.SetText(formTitle)
 		intro.SetText(formIntro)
 		content.Objects = []fyne.CanvasObject{form}
 		content.Refresh()
 	}
 
-	forms, err := loadPostmanCollection()
+	// Загрузка коллекции
+	coll, err := collection.LoadPostmanCollection("data/col.postman_collection.json")
 	if err != nil {
-		log.Error().Err(err).Msg("Error loading forms")
+		logging.Log.Error().Err(err).Msg("Error loading collection")
 		return
 	}
 
-	// Add filter entry
+	// Переменные
+	vars := make(map[string]string)
+	for _, v := range coll.Variable {
+		vars[v.Key] = v.Value
+	}
+
+	// Формы
+	var forms []ui.Form
+	for _, item := range coll.Item {
+		if len(item.Request.URL.Path) >= minURLPathLength {
+			formID := item.Request.URL.Path[1]
+			form := ui.CreateForm(item, vars)
+			forms = append(forms, ui.Form{
+				ID:    formID,
+				Title: item.Name,
+				Intro: item.Request.Description,
+				Form:  form,
+			})
+			logging.Log.Info().Str("form_id", formID).Str("name", item.Name).Msg("Added form")
+		} else {
+			logging.Log.Warn().Str("name", item.Name).Msg("Skipping item: invalid URL path length")
+		}
+	}
+
 	filterEntry := widget.NewEntry()
 	filterEntry.SetPlaceHolder("Filter by form name")
-	filterEntry.Resize(fyne.NewSize(200, 40)) // Set minimum size for filter
+	filterEntry.Resize(fyne.NewSize(200, 40))
 
-	// Create filtered forms slice
-	filteredForms := make([]Form, len(forms))
+	filteredForms := make([]ui.Form, len(forms))
 	copy(filteredForms, forms)
 
 	tree := &widget.Tree{
@@ -355,29 +90,23 @@ func main() {
 				for i, f := range filteredForms {
 					keys[i] = f.ID
 				}
-				log.Info().Strs("keys", keys).Msg("Tree ChildUIDs called for root")
 				return keys
 			}
 			return []string{}
 		},
 		IsBranch: func(uid string) bool {
-			isRoot := uid == ""
-			log.Debug().Str("uid", uid).Bool("is_root", isRoot).Msg("Tree IsBranch called")
-			return isRoot
+			return uid == ""
 		},
 		CreateNode: func(branch bool) fyne.CanvasObject {
-			log.Debug().Bool("branch", branch).Msg("Tree CreateNode called")
 			return widget.NewLabel("Form")
 		},
 		UpdateNode: func(uid string, branch bool, obj fyne.CanvasObject) {
 			if uid == "" {
-				log.Debug().Msg("Tree UpdateNode called for root")
 				obj.(*widget.Label).SetText("Forms")
 				return
 			}
 			for _, f := range filteredForms {
 				if f.ID == uid {
-					log.Debug().Str("uid", uid).Str("title", f.Title).Msg("Tree UpdateNode called")
 					obj.(*widget.Label).SetText(f.Title)
 					break
 				}
@@ -386,7 +115,6 @@ func main() {
 		OnSelected: func(uid string) {
 			for _, f := range filteredForms {
 				if f.ID == uid {
-					log.Info().Str("uid", uid).Str("form", f.Title).Msg("Tree OnSelected called")
 					a.Preferences().SetString(preferenceCurrentForm, uid)
 					setForm(f.Form, f.Title, f.Intro)
 					break
@@ -395,9 +123,8 @@ func main() {
 		},
 	}
 
-	// Add filter functionality
 	filterEntry.OnChanged = func(input string) {
-		filteredForms = make([]Form, 0)
+		filteredForms = make([]ui.Form, 0)
 		for _, f := range forms {
 			if strings.Contains(strings.ToLower(f.Title), strings.ToLower(input)) {
 				filteredForms = append(filteredForms, f)
@@ -410,21 +137,19 @@ func main() {
 		tree.Select(forms[0].ID)
 	}
 
-	// Create scrollable container for tree
 	treeScroll := container.NewVScroll(tree)
-	treeScroll.SetMinSize(fyne.NewSize(200, 400)) // Set minimum size for tree container
+	treeScroll.SetMinSize(fyne.NewSize(200, 400))
 
-	// Create left menu container with filter and tree
 	leftMenu := container.NewVBox(
 		filterEntry,
 		treeScroll,
 	)
-	leftMenu.Resize(fyne.NewSize(200, defaultWindowHeight)) // Set minimum size for left menu
+	leftMenu.Resize(fyne.NewSize(200, defaultWindowHeight))
 
 	split := container.NewHSplit(leftMenu, container.NewBorder(top, nil, nil, nil, content))
-	split.Offset = 0.2 // Adjust split offset for better proportions
+	split.Offset = defaultSplitOffset
 	w.SetContent(split)
 	w.Resize(fyne.NewSize(defaultWindowWidth, defaultWindowHeight))
-	log.Info().Msg("Application window created and ready")
+	logging.Log.Info().Msg("Application window created and ready")
 	w.ShowAndRun()
 }


### PR DESCRIPTION
# Pull Request: Refactor — Split Application into Packages

**Base branch:** `main`  
**Compare branch:** `refactor/use-diff-packages`

---

## Summary

- **Major refactoring:** the application is now split into logical packages:
  - `internal/collection` — Postman Collection parsing and variable substitution
  - `internal/httpclient` — HTTP client logic and request/response handling
  - `internal/ui` — Fyne UI logic and form creation
  - `internal/logging` — zerolog initialization and logging helpers
- `main.go` now only contains application startup and component wiring.
- **Added unit tests** for `collection` and `httpclient` packages.
- **Added Makefile targets** for test coverage (`make coverage`, alias `make cov`), with reports saved in `./docs/`.
- **Updated `.gitignore`** to exclude coverage artifacts.
- **Updated `README.md`** with instructions for running and viewing test coverage.

---

## How to test

1. **Run the application as before:**
   ```bash
   make run
   ```
2. **Run all tests and check coverage:**
   ```bash
   make coverage
   # or
   make cov
   ```
   Open `docs/coverage.html` in your browser for a detailed report.

---

## Motivation

- Improves code maintainability and readability.
- Makes it easier to add new features and tests.
- Keeps the project structure clean and scalable.

---

**Please review the new structure and test coverage. Feedback and suggestions are welcome!**