### PR TITLE
feat: Embed FyneApp.toml for installation

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,6 +37,9 @@ const (
 	appID    = "com.github.romanitalian.ghostman"
 	appTitle = "GHOSTman"
 )
+
+//go:embed FyneApp.toml
+var _ []byte
 
 var (
 	topWindow   fyne.Window


### PR DESCRIPTION
### feat: Embed FyneApp.toml for installation

This PR fixes an issue with `fyne install` where it failed to locate the `FyneApp.toml` metadata file, preventing successful cross-platform installation from the repository URL.

#### Problem

When using `fyne install github.com/romanitalian/GHOSTman@latest`, the build would fail with the following error:
`failed to load metadata: open /.../FyneApp.toml: no such file or directory`

This occurred because the Go module system, which `fyne install` relies on, does not include non-Go source files (like `.toml` files) when fetching a remote module. As a result, the Fyne build tools could not find the necessary application metadata.

#### Solution

To resolve this, `FyneApp.toml` is now embedded directly into the application binary using the `//go:embed` directive in `main.go`. This ensures that the metadata is always available to the build tools, making the application self-contained and installable from any location.

#### Changes

-   **`main.go`**: Added the `//go:embed FyneApp.toml` directive and imported the `embed` package to include the metadata file in the build.
-   **`changelog-*.md`**: Added a changelog file with the plan for the fix.